### PR TITLE
Fix possible ReDOS in newline rule.

### DIFF
--- a/app/assets/javascripts/pretty-text/engines/discourse-markdown/newline.js
+++ b/app/assets/javascripts/pretty-text/engines/discourse-markdown/newline.js
@@ -8,6 +8,7 @@ function newline(state, silent) {
   let token,
     pmax,
     max,
+    ws,
     pos = state.pos;
 
   if (state.src.charCodeAt(pos) !== 0x0a /* \n */) {
@@ -24,7 +25,11 @@ function newline(state, silent) {
   if (!silent) {
     if (pmax >= 0 && state.pending.charCodeAt(pmax) === 0x20) {
       if (pmax >= 1 && state.pending.charCodeAt(pmax - 1) === 0x20) {
-        state.pending = state.pending.replace(/ +$/, "");
+         // Find whitespaces tail of pending chars.
+        ws = pmax - 1;
+        while (ws >= 1 && state.pending.charCodeAt(ws - 1) === 0x20) ws--;
+
+        state.pending = state.pending.slice(0, ws);
         token = state.push("hardbreak", "br", 0);
       } else {
         state.pending = state.pending.slice(0, -1);


### PR DESCRIPTION
Fix possible ReDOS in newline rule.

You can refer the [commit](https://github.com/markdown-it/markdown-it/commit/ffc49ab46b5b751cd2be0aabb146f2ef84986101)